### PR TITLE
Add last update timestamp for products with UI and database updates

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -1,5 +1,16 @@
 /* WP Licensing Manager Admin Styles */
 
+/* Products Table */
+.wp-list-table th:nth-child(7),
+.wp-list-table td:nth-child(7) {
+    width: 140px;
+    white-space: nowrap;
+}
+
+.wp-list-table td:nth-child(7) span {
+    font-style: italic;
+}
+
 /* Stats Grid */
 .wp-licensing-stats-grid {
     display: grid;

--- a/admin/views/products.php
+++ b/admin/views/products.php
@@ -90,13 +90,14 @@ $total_pages = $products_data['pages'];
                 <th scope="col"><?php esc_html_e('Update File', 'wp-licensing-manager'); ?></th>
                 <th scope="col"><?php esc_html_e('Licenses', 'wp-licensing-manager'); ?></th>
                 <th scope="col"><?php esc_html_e('Created', 'wp-licensing-manager'); ?></th>
+                <th scope="col"><?php esc_html_e('Last Update', 'wp-licensing-manager'); ?></th>
                 <th scope="col"><?php esc_html_e('Actions', 'wp-licensing-manager'); ?></th>
             </tr>
         </thead>
         <tbody>
             <?php if (empty($products)): ?>
                 <tr>
-                    <td colspan="7"><?php esc_html_e('No products found.', 'wp-licensing-manager'); ?></td>
+                    <td colspan="8"><?php esc_html_e('No products found.', 'wp-licensing-manager'); ?></td>
                 </tr>
             <?php else: ?>
                 <?php foreach ($products as $product): ?>
@@ -121,6 +122,15 @@ $total_pages = $products_data['pages'];
                             </a>
                         </td>
                         <td><?php echo esc_html(date_i18n(get_option('date_format'), strtotime($product->created_at))); ?></td>
+                        <td>
+                            <?php 
+                            if (!empty($product->updated_at) && $product->updated_at !== $product->created_at) {
+                                echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($product->updated_at)));
+                            } else {
+                                echo '<span style="color: #666;">' . esc_html__('Never', 'wp-licensing-manager') . '</span>';
+                            }
+                            ?>
+                        </td>
                         <td>
                             <a href="#" class="button button-small edit-product" data-product-id="<?php echo esc_attr($product->id); ?>"><?php esc_html_e('Edit', 'wp-licensing-manager'); ?></a>
                             <a href="#" class="button button-small view-integration" data-product-slug="<?php echo esc_attr($product->slug); ?>"><?php esc_html_e('Integration', 'wp-licensing-manager'); ?></a>

--- a/includes/class-product-manager.php
+++ b/includes/class-product-manager.php
@@ -174,6 +174,10 @@ class WP_Licensing_Manager_Product_Manager {
             return false;
         }
 
+        // Always update the updated_at timestamp
+        $update_data['updated_at'] = current_time('mysql');
+        $update_format[] = '%s';
+
         $result = $wpdb->update(
             $wpdb->prefix . 'license_products',
             $update_data,

--- a/wp-licensing-manager.php
+++ b/wp-licensing-manager.php
@@ -245,6 +245,7 @@ class WP_Licensing_Manager {
             changelog text,
             update_file_path varchar(255),
             created_at timestamp DEFAULT CURRENT_TIMESTAMP,
+            updated_at timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             UNIQUE KEY slug (slug)
         ) $charset_collate;";
@@ -253,6 +254,12 @@ class WP_Licensing_Manager {
         dbDelta($licenses_sql);
         dbDelta($activations_sql);
         dbDelta($products_sql);
+        
+        // Migration: Add updated_at column to existing products table if it doesn't exist
+        $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $products_table LIKE 'updated_at'");
+        if (empty($column_exists)) {
+            $wpdb->query("ALTER TABLE $products_table ADD COLUMN updated_at timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at");
+        }
     }
 
     /**


### PR DESCRIPTION
CHANGES MADE:
1. Database Schema Update
✅ Added updated_at column to license_products table
✅ Default value: CURRENT_TIMESTAMP
✅ Auto-update: ON UPDATE CURRENT_TIMESTAMP
✅ Migration script for existing installations
2. Products Table Enhancement
✅ Added "Last Update" column header
✅ Positioned between "Created" and "Actions" columns
✅ Updated colspan for "No products found" message
3. Display Logic
✅ Shows date + time when product was last updated
✅ Shows "Never" (grayed out) if product hasn't been updated since creation
✅ Uses WordPress date/time format settings
✅ Properly escaped output for security
4. Update Mechanism
✅ Product manager automatically sets updated_at on every update
✅ File uploads trigger timestamp update
✅ Version changes update timestamp
✅ Changelog updates trigger timestamp
5. CSS Styling
✅ Fixed column width (140px) to prevent wrapping
✅ Proper spacing and alignment
✅ "Never" text styled in gray italic
📊 HOW IT WORKS:
🆕 New Products:
Created: 2025-08-02 10:00:00
Updated: 2025-08-02 10:00:00 (same as created)
Display: "Never" (grayed out)
📝 Updated Products:
Created: 2025-08-02 10:00:00
Updated: 2025-08-02 14:30:00 (different from created)
Display: "2025-08-02 14:30:00"
🔄 Upload Workflow Integration:
When you upload a new version:

User uploads new ZIP file with version number
System updates database (version, changelog, file path)
updated_at timestamp automatically updates
Products table shows new "Last Update" time
Easy to track recent changes!
🎯 BENEFITS:
✅ Track Activity - See which products have been recently updated
✅ Version Management - Know when last updates were uploaded
✅ Team Coordination - Multiple admins can see recent changes
✅ User-Friendly - Clear visual indication of product freshness
✅ Professional - Adds polish to the admin interface

🎉 RESULT:
Your Products table now includes a "Last Update" column that shows:

⏰ Timestamp when the product was last modified
🆕 "Never" for products that haven't been updated since creation
📅 Formatted dates using WordPress settings
🎨 Clean styling that fits the admin interface
Perfect for tracking version update activity! 🚀