### PR TITLE
Bump version to 1.1.0 and update plugin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,13 @@ $body = json_decode(wp_remote_retrieve_body($response), true);
 if ($body['success']) {
     // License is valid
 }
+```
+
+## About
+
+**Version:** 1.1.0  
+**Author:** StackCastle  
+**Website:** [https://stackcastle.com/](https://stackcastle.com/)  
+**License:** GPL v2 or later
+
+For support and documentation, visit [https://stackcastle.com/wp-licensing-manager](https://stackcastle.com/wp-licensing-manager)

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -429,7 +429,7 @@ class WP_Licensing_Manager_API {
         return new WP_REST_Response(array(
             'success' => true,
             'message' => 'WP Licensing Manager API is working correctly',
-            'version' => '1.0.0',
+            'version' => '1.1.0',
             'endpoints' => array(
                 'POST /licensing/v1/validate' => 'Validate a license key',
                 'POST /licensing/v1/activate' => 'Activate a license on a domain',

--- a/index.php
+++ b/index.php
@@ -498,7 +498,7 @@ echo "<h1>WP Licensing Manager - Plugin Test Environment</h1>\n";
 echo "<div class='plugin-info'>\n";
 echo "<h2>Plugin Information</h2>\n";
 echo "<p><strong>Name:</strong> WP Licensing Manager</p>\n";
-echo "<p><strong>Version:</strong> 1.0.0</p>\n";
+    echo "<p><strong>Version:</strong> 1.1.0</p>\n";
 echo "<p><strong>Description:</strong> A comprehensive licensing system for WordPress plugins and themes</p>\n";
 echo "</div>\n";
 

--- a/wp-licensing-manager.php
+++ b/wp-licensing-manager.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Plugin Name: WP Licensing Manager
- * Plugin URI: https://example.com/wp-licensing-manager
+ * Plugin URI: https://stackcastle.com/wp-licensing-manager
  * Description: A comprehensive licensing system for WordPress plugins and themes with WooCommerce integration.
- * Version: 1.0.0
- * Author: Your Name
- * Author URI: https://example.com
+ * Version: 1.1.0
+ * Author: StackCastle
+ * Author URI: https://stackcastle.com/
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: wp-licensing-manager
@@ -23,7 +23,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('WP_LICENSING_MANAGER_VERSION', '1.0.0');
+define('WP_LICENSING_MANAGER_VERSION', '1.1.0');
 define('WP_LICENSING_MANAGER_PLUGIN_FILE', __FILE__);
 define('WP_LICENSING_MANAGER_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WP_LICENSING_MANAGER_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
 PLUGIN INFORMATION UPDATED SUCCESSFULLY!
I've updated all the necessary plugin information with StackCastle branding:

🔄 CHANGES MADE:
1. Plugin Header (wp-licensing-manager.php):
✅ Author: Changed from "Your Name" to "StackCastle"
✅ Author URI: Changed from "https://example.com" to "https://stackcastle.com/"
✅ Plugin URI: Changed to "https://stackcastle.com/wp-licensing-manager"
✅ Version: Updated from "1.0.0" to "1.1.0"
2. Plugin Constants:
✅ WP_LICENSING_MANAGER_VERSION: Updated to "1.1.0"
3. API Status Endpoint:
✅ Version Response: Updated to "1.1.0" in API status
4. Index Page:
✅ Version Display: Updated to show "1.1.0"
5. README File:
✅ Added About Section with StackCastle information
✅ Version: 1.1.0
✅ Author: StackCastle
✅ Website Links: https://stackcastle.com/
📋 UPDATED PLUGIN INFORMATION:
Plugin Name: WP Licensing Manager
Version: 1.1.0
Author: StackCastle
Author URI: https://stackcastle.com/
Plugin URI: https://stackcastle.com/wp-licensing-manager
🎯 WHAT REMAINS AS 1.0.0:
These default values were intentionally kept as 1.0.0 since they represent starting versions for new products:

✅ Default product version in forms (1.0.0)
✅ Database default version for new products (1.0.0)
✅ JavaScript defaults for new products (1.0.0)
This is correct behavior - new products should start at version 1.0.0!

🎉 SUMMARY:
All StackCastle branding has been applied successfully!

✅ Author: StackCastle
✅ Website: https://stackcastle.com/
✅ Plugin Version: 1.1.0
✅ Documentation: Updated README with proper attribution
✅ API Version: Reflects new version number

Your WP Licensing Manager plugin now properly reflects StackCastle branding and is ready for distribution! 🚀